### PR TITLE
fix: HPA in ArgoCD is always out-of-sync

### DIFF
--- a/bls-chart/templates/hpa.yaml
+++ b/bls-chart/templates/hpa.yaml
@@ -15,7 +15,12 @@ spec:
     name: {{ .Values.name }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
-  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
 {{- end }}
 {{- end }}
-  


### PR DESCRIPTION
According to https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics the property `targetCPUUtilizationPercentage` is deprecated and has been replaced by the metrics array. 

The old property still seems to be automatically replaced by some tool in the pipeline, but then causes out-of-sync issues in ArgoCD. See 