### PR TITLE
feat(DO-871): add support for Ingress className and set it to traefik per default

### DIFF
--- a/bls-chart/templates/ingress.yaml
+++ b/bls-chart/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     app: {{ .Values.name }}
     app.kubernetes.io/managed-by: helm
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ . }}

--- a/bls-chart/values.yaml
+++ b/bls-chart/values.yaml
@@ -23,6 +23,7 @@ service:
 
 ingress:
   enabled: true
+  className: traefik
   hosts:
     - example.com
   paths:


### PR DESCRIPTION
Extend `Ingress` object with support for `className` and set it per default to `traefik`